### PR TITLE
[change] option in lighthouse-ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:logo": "./buildlogo.js",
     "lh": "lighthouse-ci",
     "test": "cross-env NODE_PATH=src/ react-scripts test --env=jsdom --coverage",
-    "test:lh": "yarn lh --perf=95 --seo=100 --pwa=100 --a11y=100 --bp=100",
+    "test:lh": "yarn lh --performance=95 --seo=100 --pwa=100 --accessibility=100 --best-practices=100",
     "eject": "react-scripts eject",
     "build:storybook": "build-storybook -s public",
     "storybook": "start-storybook -p 9009 -s public",


### PR DESCRIPTION
this is an option on version 1.3.1
```
Options
    -s, --silent                  Run Lighthouse without printing report log.
    --report=<path>               Generate an HTML report inside a specified folder.
    --score=<threshold>           Specify a score threshold for the CI to pass.
    --performance=<threshold>     Specify a minimal performance score for the CI to pass.
    --pwa=<threshold>             Specify a minimal pwa score for the CI to pass.
    --accessibility=<threshold>   Specify a minimal accessibility score for the CI to pass.
    --best-practice=<threshold>   [DEPRECATED] Use best-practices instead.
    --best-practices=<threshold>  Specify a minimal best-practice score for the CI to pass.
    --seo=<threshold>             Specify a minimal seo score for the CI to pass.
```